### PR TITLE
fix(add address_filter to listReceivedByAddress, verbose to getTransa…

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -335,9 +335,10 @@ export class Client {
 
   getTransaction = (
     txid: string,
-    include_watchonly?: boolean
+    include_watchonly?: boolean,
+    verbose?: boolean
   ): Promise<WalletTransaction> =>
-    this.makeCall('getTransaction', txid, include_watchonly)
+    this.makeCall('getTransaction', txid, include_watchonly, verbose)
 
   getTxOut = (
     txid: string,
@@ -424,13 +425,15 @@ export class Client {
   listReceivedByAddress = (
     minconf = 1,
     include_empty = false,
-    include_watchonly?: boolean
+    include_watchonly?: boolean,
+    address_filter?: string
   ): Promise<ReceivedByAddress[]> =>
     this.makeCall(
       'listReceivedByAddress',
       minconf,
       include_empty,
-      include_watchonly
+      include_watchonly,
+      address_filter
     )
 
   listSinceBlock = (


### PR DESCRIPTION
…ction)

There were a few arguments missing from these methods.

Love the library by the way! Thank you for making it.

Doc ref: 
https://bitcoincore.org/en/doc/0.21.0/rpc/wallet/gettransaction/
https://bitcoincore.org/en/doc/0.21.0/rpc/wallet/listreceivedbyaddress/